### PR TITLE
Fix 'Cache Types' columns

### DIFF
--- a/documentation/Chrome Cache file format.asciidoc
+++ b/documentation/Chrome Cache file format.asciidoc
@@ -62,7 +62,7 @@ persistent cached data.
 === Cache types
 The following file-based cache types (CacheType) are known:
 
-[cols="1,2",options="header"]
+[cols="1,2,3",options="header"]
 |===
 | Value | Identifier | Description
 | 0 | DISK_CACHE | On-disk HTTP response headers and web content cache

--- a/documentation/Chrome Cache file format.asciidoc
+++ b/documentation/Chrome Cache file format.asciidoc
@@ -62,7 +62,7 @@ persistent cached data.
 === Cache types
 The following file-based cache types (CacheType) are known:
 
-[cols="1,2,3",options="header"]
+[cols="1,2,5",options="header"]
 |===
 | Value | Identifier | Description
 | 0 | DISK_CACHE | On-disk HTTP response headers and web content cache


### PR DESCRIPTION
Minor change to make the columns under "1.1. Cache types" display correctly.