### PR TITLE
Unified Logs: Oversize Data Reference of Log Firehose Tracepoint is 4 bytes

### DIFF
--- a/documentation/Apple Unified Logging and Activity Tracing formats.asciidoc
+++ b/documentation/Apple Unified Logging and Activity Tracing formats.asciidoc
@@ -52,6 +52,7 @@ in the section entitled "GNU Free Documentation License".
 | 0.0.8 | Fry | November 2022 | Additional changes based on format analysis.
 | 0.0.9 | J.B. Metz | May 2023 | Additional changes based on format analysis.
 | 0.0.10 | J.B. Metz | June 2023 | Additional changes based on format analysis.
+| 0.0.11 | L. Arnold | April 2024 | Additional changes based on format analysis.
 |===
 
 :numbered:
@@ -983,8 +984,8 @@ Where the range offset is a virtual private strings offset in the <<tracev3_fire
 4+| _Has rules flag (0x0400) is set_
 | ... | 1 | | TTL
 4+| _Has oversize data reference flag (0x0800) is set_
-| ... | 2 | | Oversize data reference
-4+| _Common_
+| ... | 4 | | Oversize data reference
+4+| _Has oversize data reference flag (0x0800) is not set_
 | ... | 1 | | [yellow-background]*Unknown*
 | ... | 1 | | Number of data items
 | ... | number of data items | | Array of data items +


### PR DESCRIPTION
Hi,

Thanks for your awesome documentation for various binary formats. While working with the macos-unifiedlogs library, I encountered an issue with oversize data references from firehose log tracepoints to oversize chunks. You can find more about it at https://github.com/mandiant/macos-UnifiedLogs/pull/13.

In summary, I observed that the field `oversize data reference` of firehose log tracepoints has a size of 4 and not 2 bytes. This change ensures consistency with the field `data reference` of oversize chunks, which also has a length of 4 bytes. After this change, the library could assign more log tracepoints to oversize data. 

Furthermore, I noticed that if oversize data is present, no data items are stored within the original firehose chunk. Is my notiation for this obersavation acceptable or have you observed something different?

Best
Lukas